### PR TITLE
Fix vietnamese translation

### DIFF
--- a/po/vi.po
+++ b/po/vi.po
@@ -33,7 +33,7 @@ msgstr "Gnome;GTK;"
 
 #: data/org.gnome.Tour.metainfo.xml.in.in:8
 msgid "GNOME Tour and Greeter"
-msgstr "Giới thiệu & Thăm quan GNOME"
+msgstr "Giới thiệu và Thăm quan GNOME"
 
 #: data/org.gnome.Tour.metainfo.xml.in.in:10
 msgid "A guided tour and greeter for GNOME."


### PR DESCRIPTION
Using '&' is appealing, but the translated string is used in .xml files
and also in .desktop files. Gettext 0.25+ no longer escapes the translations
when merging them into xml files, which would mean we'd need `&amp;` - that
in turn would not be parsed by the desktops and would result in the string
being shown literally.

Avoid the usage of '&' in this case
