### PR TITLE
Rename minimal bin to opensuse-welcome

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Bilal Elmoussaoui <bil.elmoussaoui@gmail.com>"]
 edition = "2021"
 
 [[bin]]
-name = "gnome-tour-minimal"
+name = "opensuse-welcome"
 path = "src/minimal.rs"
 
 [dependencies]

--- a/data/meson.build
+++ b/data/meson.build
@@ -30,6 +30,7 @@ endif
 # Desktop file
 desktop_conf = configuration_data()
 desktop_conf.set('icon', application_id)
+desktop_conf.set('exec', 'gnome-tour')
 desktop_file = i18n.merge_file (
   type: 'desktop',
   input: configure_file(
@@ -53,18 +54,18 @@ if desktop_file_validate.found()
   )
 endif
 
-# Desktop file minimal
+# Desktop file opensuse
 desktop_conf = configuration_data()
 desktop_conf.set('icon', application_id)
-desktop_conf.set('suffix', '-minimal')
-desktop_file_minimal = i18n.merge_file (
+desktop_conf.set('exec', 'opensuse-welcome')
+desktop_file_opensuse = i18n.merge_file (
   type: 'desktop',
   input: configure_file(
     input: '@0@.desktop.in.in'.format(base_id),
-    output: '@BASENAME@-minimal',
+    output: 'org.opensuse.Welcome.desktop.in',
     configuration: desktop_conf
   ),
-  output: '@0@.desktop'.format(application_id + 'Minimal'),
+  output: '@0@.desktop'.format('org.opensuse.Welcome'),
   po_dir: podir,
   install: true,
   install_dir: datadir / 'applications'
@@ -77,7 +78,7 @@ if desktop_file_validate.found()
     desktop_file_validate,
     args: [
       desktop_file.full_path(),
-      desktop_file_minimal.full_path()
+      desktop_file_opensuse.full_path()
     ]
   )
 endif
@@ -96,6 +97,7 @@ resources = gnome.compile_resources(
 service_conf = configuration_data()
 service_conf.set('app-id', application_id)
 service_conf.set('bindir', bindir)
+service_conf.set('exec', 'gnome-tour')
 configure_file(
   input: '@0@.service.in'.format(base_id),
   output: '@0@.service'.format(application_id),
@@ -103,14 +105,14 @@ configure_file(
   install_dir: datadir / 'dbus-1' / 'services'
 )
 
-# D-Bus service minimal
+# D-Bus service opensuse
 service_conf = configuration_data()
-service_conf.set('app-id', application_id + 'Minimal')
+service_conf.set('app-id', 'org.opensuse.Welcome')
 service_conf.set('bindir', bindir)
-service_conf.set('suffix', '-minimal')
+service_conf.set('exec', 'opensuse-welcome')
 configure_file(
   input: '@0@.service.in'.format(base_id),
-  output: '@0@.service'.format(application_id + 'Minimal'),
+  output: '@0@.service'.format('org.opensuse.Welcome'),
   configuration: service_conf,
   install_dir: datadir / 'dbus-1' / 'services'
 )

--- a/data/org.gnome.Tour.desktop.in.in
+++ b/data/org.gnome.Tour.desktop.in.in
@@ -2,7 +2,7 @@
 Name=Tour
 GenericName=Greeter & Tour
 Type=Application
-Exec=gnome-tour@suffix@
+Exec=@exec@
 Terminal=false
 Categories=GNOME;GTK;Documentation;Utility;
 Keywords=Gnome;GTK;

--- a/data/org.gnome.Tour.service.in
+++ b/data/org.gnome.Tour.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=@app-id@
-Exec=@bindir@/gnome-tour@suffix@ --gapplication-service
+Exec=@bindir@/@exec@ --gapplication-service

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,10 +53,10 @@ custom_target(
 )
 
 custom_target(
-  'cargo-build-minimal',
+  'cargo-build-opensuse',
   build_by_default: true,
   build_always_stale: true,
-  output: meson.project_name() + '-minimal',
+  output: 'opensuse-welcome',
   console: true,
   install: true,
   install_dir: bindir,
@@ -67,7 +67,7 @@ custom_target(
     cargo, 'build',
     cargo_options,
     '&&',
-    'cp', 'src' / rust_target / meson.project_name() + '-minimal', '@OUTPUT@',
+    'cp', 'src' / rust_target / 'opensuse-welcome', '@OUTPUT@',
   ]
 )
 

--- a/src/minimal.rs
+++ b/src/minimal.rs
@@ -33,5 +33,6 @@ fn main() -> glib::ExitCode {
     unsafe {
         app.set_data("minimal", true);
     }
+    app.set_application_id(Some("org.opensuse.Welcome"));
     app.run()
 }


### PR DESCRIPTION
Use opensuse-welcome instead of gnome-tour-minimal, to differentiate the application.